### PR TITLE
Category prefixing and string constants

### DIFF
--- a/XNGOAuth1Client/NSDictionary+XNGOAuth1Additions.h
+++ b/XNGOAuth1Client/NSDictionary+XNGOAuth1Additions.h
@@ -1,9 +1,9 @@
 @interface NSDictionary (XNGOAuth1Additions)
 
-+ (id)xngo_dictionaryFromQueryString:(NSString *)queryString;
++ (id)xng_dictionaryFromQueryString:(NSString *)queryString;
 
-- (id)xngo_initWithQueryString:(NSString *)queryString;
+- (id)xng_initWithQueryString:(NSString *)queryString;
 
-- (NSString *)xngo_queryStringRepresentation;
+- (NSString *)xng_queryStringRepresentation;
 
 @end

--- a/XNGOAuth1Client/NSDictionary+XNGOAuth1Additions.m
+++ b/XNGOAuth1Client/NSDictionary+XNGOAuth1Additions.m
@@ -3,29 +3,29 @@
 
 @implementation NSDictionary (XNGOAuth1Additions)
 
-+ (id)xngo_dictionaryFromQueryString:(NSString *)queryString {
-    return [[NSDictionary alloc] xngo_initWithQueryString:queryString];
++ (id)xng_dictionaryFromQueryString:(NSString *)queryString {
+    return [[NSDictionary alloc] xng_initWithQueryString:queryString];
 }
 
-- (id)xngo_initWithQueryString:(NSString *)queryString {
+- (id)xng_initWithQueryString:(NSString *)queryString {
     NSArray *components = [queryString componentsSeparatedByString:@"&"];
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
 
     for (NSString *component in components) {
         NSArray *keyValue = [component componentsSeparatedByString:@"="];
-        NSString *key = [keyValue[0] xngo_URLDecode];
-        NSString *value = [keyValue[1] xngo_URLDecode];
+        NSString *key = [keyValue[0] xng_URLDecode];
+        NSString *value = [keyValue[1] xng_URLDecode];
         [dictionary setObject:value forKey:key];
     }
 
     return dictionary;
 }
 
-- (NSString *)xngo_queryStringRepresentation {
+- (NSString *)xng_queryStringRepresentation {
     NSMutableArray *paramArray = [NSMutableArray array];
 
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
-        NSString *param = [NSString stringWithFormat:@"%@=%@", [key xngo_URLEncode], [value xngo_URLEncode]];
+        NSString *param = [NSString stringWithFormat:@"%@=%@", [key xng_URLEncode], [value xng_URLEncode]];
         [paramArray addObject:param];
     }];
 

--- a/XNGOAuth1Client/NSString+XNGOAuth1Additions.h
+++ b/XNGOAuth1Client/NSString+XNGOAuth1Additions.h
@@ -1,7 +1,7 @@
 @interface NSString (XNGOAuth1Additions)
 
-- (NSString *)xngo_URLEncode;
+- (NSString *)xng_URLEncode;
 
-- (NSString *)xngo_URLDecode;
+- (NSString *)xng_URLDecode;
 
 @end

--- a/XNGOAuth1Client/NSString+XNGOAuth1Additions.m
+++ b/XNGOAuth1Client/NSString+XNGOAuth1Additions.m
@@ -2,7 +2,7 @@
 
 @implementation NSString (XNGOAuth1Additions)
 
-- (NSString *)xngo_URLEncode {
+- (NSString *)xng_URLEncode {
     return (__bridge_transfer NSString *)
             CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
                     (__bridge CFStringRef)self,
@@ -11,7 +11,7 @@
                     kCFStringEncodingUTF8);
 }
 
-- (NSString *)xngo_URLDecode {
+- (NSString *)xng_URLDecode {
     return (__bridge_transfer NSString *)
             CFURLCreateStringByReplacingPercentEscapesUsingEncoding(kCFAllocatorDefault,
                     (__bridge CFStringRef)self,

--- a/XNGOAuth1Client/XNGOAuthToken.m
+++ b/XNGOAuth1Client/XNGOAuthToken.m
@@ -32,7 +32,7 @@ static NSString *const XNGOAuthTokenDurationKey = @"oauth_token_duration";
         return nil;
     }
 
-    NSDictionary *attributes = [NSDictionary xngo_dictionaryFromQueryString:queryString];
+    NSDictionary *attributes = [NSDictionary xng_dictionaryFromQueryString:queryString];
 
     if (attributes.allKeys.count == 0) {
         return nil;

--- a/XNGOAuth1ClientTests/NSDictionaryAdditionsTests.m
+++ b/XNGOAuth1ClientTests/NSDictionaryAdditionsTests.m
@@ -12,7 +12,7 @@
 
 - (void)testInitializer {
     NSString *queryString = @"param1=HELLO&param2=XING";
-    NSDictionary *resultDict = [[NSDictionary alloc] xngo_initWithQueryString:queryString];
+    NSDictionary *resultDict = [[NSDictionary alloc] xng_initWithQueryString:queryString];
 
     expect(resultDict[@"param1"]).to.equal(@"HELLO");
     expect(resultDict[@"param2"]).to.equal(@"XING");
@@ -20,7 +20,7 @@
 
 - (void)testClassMethod {
     NSString *queryString = @"param1=HELLO&param2=XING";
-    NSDictionary *resultDict = [NSDictionary xngo_dictionaryFromQueryString:queryString];
+    NSDictionary *resultDict = [NSDictionary xng_dictionaryFromQueryString:queryString];
 
     expect(resultDict[@"param1"]).to.equal(@"HELLO");
     expect(resultDict[@"param2"]).to.equal(@"XING");
@@ -30,7 +30,7 @@
     NSDictionary *dictionary = @{
             @"param1": @"HELLO",
             @"param2": @"XING"};
-    NSString *queryString = [dictionary xngo_queryStringRepresentation];
+    NSString *queryString = [dictionary xng_queryStringRepresentation];
     expect(queryString).to.equal(@"param1=HELLO&param2=XING");
 }
 


### PR DESCRIPTION
I choose xngo as prefix to not clash with XNGAPIClient categories. 
